### PR TITLE
Initial refactor and support for multiple-monitors

### DIFF
--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -1,56 +1,24 @@
 # Wrap a gamestream session around a launcher program with configurable background tasks and resolution switching
-import win32api
-import win32.lib.win32con as win32con
-import win32gui
-import pywintypes
-import pyautogui
-import configparser
-import subprocess
-import psutil
 import os
 import sys
+import time
+import ctypes
+import argparse
+import subprocess
+import configparser
+from copy import copy
 from time import sleep
+from pathlib import Path
+from contextlib import contextmanager
 
-# Window enumeration handler function per https://www.blog.pythonlibrary.org/2014/10/20/pywin32-how-to-bring-a-window-to-front/
-def windowEnumerationHandler(hwnd, top_windows):
-    top_windows.append((hwnd, win32gui.GetWindowText(hwnd)))
+import psutil
+import win32api
+import win32gui
+import pyautogui
+import pywintypes
+import win32.lib.win32con as win32con
 
-
-def set_resolution(gamestream_width, gamestream_height):
-    print("Switching resolution to {0}x{1}".format(gamestream_width, gamestream_height))
-    devmode = pywintypes.DEVMODEType()
-    devmode.PelsWidth = int(gamestream_width)
-    devmode.PelsHeight = int(gamestream_height)
-    devmode.Fields = win32con.DM_PELSWIDTH | win32con.DM_PELSHEIGHT
-    win32api.ChangeDisplaySettings(devmode, 0)
-
-
-def get_process_name(p):
-    # If there are permission errors reading a process name, it's probably not the one we want, so skip it.
-    try:
-        p_name = p.name()
-    except (PermissionError, psutil.AccessDenied):
-        p_name = ""
-        pass
-    return p_name
-
-
-def reset_launcher_resolution(gamestream_width, gamestream_height, launcher_window_name):
-    # Check to ensure desired GSLP resolution is still set whenever the launcher is in focus in case it didn't reset when exiting a game
-    focused_window = win32gui.GetWindowText(win32gui.GetForegroundWindow()).lstrip()
-    #print("Trying to match", launcher_window_name, focused_window)
-    if focused_window.startswith(launcher_window_name):
-        #print("Matched")
-        current_width = str(win32api.GetSystemMetrics(0))
-        current_height = str(win32api.GetSystemMetrics(1))
-        if current_width != gamestream_width and current_height != gamestream_height:
-            print("Resolutions don't match, changing from", current_width, current_height, "to", gamestream_width, gamestream_height)
-            set_resolution(gamestream_width, gamestream_height)
-
-
-# Define a default config file to write if we're missing one
-config_filename = 'gamestream_playnite.ini'
-default_config = """[LAUNCHER]
+DEFAULT_CONFIG = """[LAUNCHER]
 # The path to your Playnite.FullscreenApp.exe
 launcher_path = %%LOCALAPPDATA%%\Playnite\Playnite.FullscreenApp.exe
 # Name of the window to watch to close the session when it's gone
@@ -70,136 +38,234 @@ sleep_on_exit = 0
 close_watch_method = window
 """
 
-# Write the default config
-if not os.path.exists(config_filename):
-    with open(config_filename, 'w') as out_file:
-        out_file.write(default_config)
+ctypes.windll.shcore.SetProcessDpiAwareness(2)
 
-# Target resolution for gamestream environment
-try:
-    gamestream_width = sys.argv[1]
-    gamestream_height = sys.argv[2]
-    # If there's a 3rd argument after the .py/.exe, use it as a custom launcher path
-    if len(sys.argv) == 4:
-        config_filename = sys.argv[3]
-except IndexError:
-    print("Error parsing arguments. Did you mean to run one of the .bat launcher scripts?")
-    print("Usage: gamestream_launchpad.exe 1920 1080 [config.ini]")
-    input("Press Enter to exit.")
-    sys.exit(1)
 
-# Parse the config file and assume defaults otherwise
-config = configparser.ConfigParser()
-config.read(config_filename)
-cfg_launcher_path = config['LAUNCHER'].get('launcher_path', r'%LOCALAPPDATA%\Playnite\Playnite.FullscreenApp.exe')
-cfg_launcher_window_name = config['LAUNCHER'].get('launcher_window_name', 'Playnite')
-cfg_bg_paths = config['BACKGROUND']
-debug = config['SETTINGS'].get('debug', '0')
-sleep_on_exit = config['SETTINGS'].get('sleep_on_exit', '0')
-close_watch_method = config['SETTINGS'].get('close_watch_method', 'window')
+# Window enumeration handler function per
+# https://www.blog.pythonlibrary.org/2014/10/20/pywin32-how-to-bring-a-window-to-front/
+def windowEnumerationHandler(hwnd, top_windows):
+    top_windows.append((hwnd, win32gui.GetWindowText(hwnd)))
 
-launcher_exec_name = os.path.basename(cfg_launcher_path)
 
-# Set resolution to target
-set_resolution(gamestream_width, gamestream_height)
+def get_process_name(p):
+    # If there are permission errors reading a process name, it's probably not the one we want, so skip it.
+    try:
+        p_name = p.name()
+    except (PermissionError, psutil.AccessDenied):
+        p_name = ""
+    return p_name
 
-# Start background programs, if they're available
-for path in cfg_bg_paths:
-    expanded_path = os.path.expandvars(cfg_bg_paths[path])
-    if os.path.exists(expanded_path):
-        print("Launching", expanded_path)
-        exec_name = os.path.basename(expanded_path)
-        # Kill the process first if it's already running
-        if exec_name in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + exec_name)
-        # Start the process
-        subprocess.Popen(expanded_path)
 
-# A launcher value of false will create a wait inside of the console instead watching a program
-if cfg_launcher_path.lower() == "false":
-    input('Press enter to end the GameStream session.')
-else:    
-    # Minimize all windows
-    print("Minimizing windows")
-    pyautogui.hotkey('winleft', 'd')
+class GameStreamLauncher:
+    def __init__(self, launch_startup_timeout=30, watch_sleep_time=5):
+        self.displays = {}
+        self.launch_startup_timeout = launch_startup_timeout
+        self.watch_sleep_time = watch_sleep_time
 
-    # Playnite has to be killed before it will start in fullscreen mode
-    if "Playnite" in launcher_exec_name:
-        if "Playnite.FullscreenApp.exe" in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + "Playnite.FullscreenApp.exe")
-        if "Playnite.DesktopApp.exe" in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + "Playnite.DesktopApp.exe")
-    
-        # Move mouse cursor into the lower-right corner to pseudo-hide it because sticks out in playnite fullscreen
-        pyautogui.FAILSAFE = False
-        pyautogui.moveTo(9999, 9999, duration = 0)
-
-    # Start game launcher
-    print("Starting game launcher")
-    launcher_exe = os.path.expandvars(cfg_launcher_path)
-    subprocess.Popen(launcher_exe)
-
-    # Focus launcher in the foreground and maximize
-    results = []
-    top_windows = []
-    launcher_focused = False
-    while not launcher_focused:
-        win32gui.EnumWindows(windowEnumerationHandler, top_windows)
-        for i in top_windows:
-            if cfg_launcher_window_name in i[1]:
-                if not 'Fullscreen' in cfg_launcher_path:
-                    print("Maximizing", cfg_launcher_window_name)
-                    win32gui.ShowWindow(i[0], 3)
-                print("Focusing", cfg_launcher_window_name)
-                win32gui.SetForegroundWindow(i[0])
-                launcher_focused = True
-                launcher_window_handle = i[0]
-                break
-        sleep(1)
-
-    # Watch for closing the launcher window to return to the system's original configuration
-    if close_watch_method == "window":
-        print("Watching for launcher window to close")
-        while win32gui.IsWindowVisible(launcher_window_handle):
-            #print("Visible:", launcher_window_handle)
-            sleep(2)
-            reset_launcher_resolution(gamestream_width, gamestream_height, cfg_launcher_window_name)
-    # Alternative method that waits for the process to die (can be problematic if it minimizes to system tray)
-    elif close_watch_method == "process":
-        print("Watching for launcher process to die")
+        i = 0
         while True:
-            if launcher_exec_name in (get_process_name(p) for p in psutil.process_iter()):
-                sleep(2)
-                reset_launcher_resolution(gamestream_width, gamestream_height, cfg_launcher_window_name)
-            else:
+            try:
+                d = win32api.EnumDisplayDevices(None, i)
+                self.displays[d.DeviceName] = {
+                    'device': d,
+                    'settings': win32api.EnumDisplaySettings(d.DeviceName, win32con.ENUM_CURRENT_SETTINGS)
+                }
+                i += 1
+            except pywintypes.error:
                 break
-    else:
-        print("No valid close_watch_method in the config. Press Enter when you're done.")
-        input()
+        self.primary_display = next(iter(k for k, v in self.displays.items()
+                                         if v['settings'].Position_x == 0 and v['settings'].Position_y == 0))
+        self._active_display = ''
 
-# Terminate background programs, if they're available
-for path in cfg_bg_paths:
-    expanded_path = os.path.expandvars(cfg_bg_paths[path])
-    if os.path.exists(expanded_path):
-        exec_name = os.path.basename(expanded_path)
-        print("Terminating", exec_name)
-        if exec_name in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + exec_name)
+    def _change_display_settings(self, display, devmode, resolution, pos=None, primary=False):
+        if pos is None:
+            pos = (self.displays[display]['settings'].Position_x, self.displays[display]['settings'].Position_y)
+        print(f"Setting display to {display} {resolution[0]}x{resolution[1]}+{pos[0]},{pos[1]}")
+        devmode.PelsWidth = int(resolution[0])
+        devmode.PelsHeight = int(resolution[1])
+        devmode.Position_x = int(pos[0])
+        devmode.Position_y = int(pos[1])
+        devmode.Fields = win32con.DM_PELSWIDTH | win32con.DM_PELSHEIGHT | win32con.DM_POSITION
+        win32api.ChangeDisplaySettingsEx(display, devmode, win32con.CDS_SET_PRIMARY if primary else 0)
 
-# Kill gamestream
-print("Terminating GameStream session.")
-if "nvstreamer.exe" in (get_process_name(p) for p in psutil.process_iter()):
-    os.system('taskkill /f /im nvstreamer.exe')
+    @contextmanager
+    def display_resolution(self, resolution, target_display=None):
+        target_display = target_display or self.primary_display
+        if target_display.lower() == 'primary':
+            target_display = self.primary_display
+        try:
+            devmode = win32api.EnumDisplaySettings(target_display, win32con.ENUM_CURRENT_SETTINGS)
+            self._change_display_settings(target_display, devmode, resolution, (0, 0), False)
+            self._active_display = target_display
+            yield
+        finally:
+            # Restore original layout
+            win32api.ChangeDisplaySettings(None, 0)
 
-# Restore original resolution
-print('Restoring original resolution.')
-win32api.ChangeDisplaySettings(None, 0)
+    def is_process_running(self, name):
+        return name in (get_process_name(p) for p in psutil.process_iter() if p)
 
-if sleep_on_exit == '1':
-# Put computer to sleep
-    print("Going to sleep")
-    os.system("rundll32.exe powrprof.dll,SetSuspendState 0,1,0")
+    def get_window_handle(self, name):
+        top_windows = []
+        win32gui.EnumWindows(windowEnumerationHandler, top_windows)
+        try:
+            return next(iter(_[0] for _ in top_windows if _[1] == name))
+        except StopIteration:
+            return None
 
-if debug == '1':
-    # Leave window open for debugging
-    input("Paused for debug review. Press Enter key to close.")
+    def run_launcher(self, resolution, config_file=None, target_display='primary'):
+        # Define a default config file to write if we're missing one
+        config_file = Path(config_file or 'gamestream_playnite.ini')
+        if not config_file.is_file():
+            with config_file.open('w') as out_file:
+                out_file.write(DEFAULT_CONFIG)
+
+        # Parse the config file and assume defaults otherwise
+        config = configparser.ConfigParser()
+        config.read(config_file.as_posix())
+        cfg_launcher_path = config['LAUNCHER'].get('launcher_path',
+                                                   r'%LOCALAPPDATA%\Playnite\Playnite.FullscreenApp.exe')
+        cfg_launcher_window_name = config['LAUNCHER'].get('launcher_window_name', 'Playnite')
+        cfg_bg_paths = config['BACKGROUND']
+        debug = config['SETTINGS'].get('debug', '0')
+        sleep_on_exit = config['SETTINGS'].get('sleep_on_exit', '0')
+        close_watch_method = config['SETTINGS'].get('close_watch_method', 'window')
+
+        launcher_exec_name = os.path.basename(cfg_launcher_path)
+
+        # Set resolution to target
+        with self.display_resolution(resolution, target_display):
+
+            # Start background programs, if they're available
+            for path in cfg_bg_paths:
+                expanded_path = os.path.expandvars(cfg_bg_paths[path])
+                if os.path.exists(expanded_path):
+                    print("Launching", expanded_path)
+                    exec_name = os.path.basename(expanded_path)
+                    # Kill the process first if it's already running
+                    if exec_name in (get_process_name(p) for p in psutil.process_iter()):
+                        os.system('taskkill /f /im ' + exec_name)
+                    # Start the process
+                    subprocess.Popen(expanded_path)
+
+            # A launcher value of false will create a wait inside of the console instead watching a program
+            if cfg_launcher_path.lower() == "false":
+                input('Press enter to end the GameStream session.')
+                return
+            else:
+                # Minimize all windows
+                # print("Minimizing windows")
+                # pyautogui.hotkey('winleft', 'd')
+
+                # Playnite has to be killed before it will start in fullscreen mode
+                if "Playnite" in launcher_exec_name:
+                    if "Playnite.FullscreenApp.exe" in (get_process_name(p) for p in psutil.process_iter()):
+                        os.system('taskkill /f /im ' + "Playnite.FullscreenApp.exe")
+                    if "Playnite.DesktopApp.exe" in (get_process_name(p) for p in psutil.process_iter()):
+                        os.system('taskkill /f /im ' + "Playnite.DesktopApp.exe")
+
+                    # Move mouse cursor into the lower-right corner to pseudo-hide it because sticks out in playnite
+                    # fullscreen
+                    pyautogui.FAILSAFE = False
+                    pyautogui.moveTo(9999, 9999, duration=0)
+
+                # Start game launcher
+                print("Starting game launcher")
+                launcher_exe = os.path.expandvars(cfg_launcher_path)
+                subprocess.Popen(launcher_exe)
+
+                # Focus launcher in the foreground and maximize
+                launch_timeout = self.launch_startup_timeout
+                while launch_timeout > 0:
+                    if (launcher_window_handle := self.get_window_handle(cfg_launcher_window_name)) is not None:
+                        if 'fullscreen' not in cfg_launcher_path.lower():
+                            print("Maximizing", cfg_launcher_window_name)
+                            win32gui.ShowWindow(launcher_window_handle, 3)
+                        print("Focusing", cfg_launcher_window_name)
+                        win32gui.SetForegroundWindow(launcher_window_handle)
+                        break
+                    sleep(1)
+                    launch_timeout -= 1
+                else:
+                    raise TimeoutError(f'Timeout waiting for launcher to start')
+
+                # Watch for closing the launcher window to return to the system's original configuration
+                if close_watch_method == "window":
+                    print("Watching for launcher window to close")
+                    while self.get_window_handle(cfg_launcher_window_name) is not None:
+                        # print("Visible:", launcher_window_handle)
+                        sleep(self.watch_sleep_time)
+                        # self.reset_launcher_resolution(resolution, cfg_launcher_window_name)
+
+                # Alternative method that waits for the process to die (can be problematic if it minimizes to system tray)
+                elif close_watch_method == "process":
+                    print("Watching for launcher process to die")
+                    while True:
+                        if launcher_exec_name in (get_process_name(p) for p in psutil.process_iter()):
+                            sleep(self.watch_sleep_time)
+                            # self.reset_launcher_resolution(resolution, cfg_launcher_window_name)
+                        else:
+                            break
+                else:
+                    print("No valid close_watch_method in the config. Press Enter when you're done.")
+                    input()
+
+            # Terminate background programs, if they're available
+            for path in cfg_bg_paths:
+                expanded_path = os.path.expandvars(cfg_bg_paths[path])
+                if os.path.exists(expanded_path):
+                    exec_name = os.path.basename(expanded_path)
+                    print("Terminating", exec_name)
+                    if exec_name in (get_process_name(p) for p in psutil.process_iter()):
+                        os.system('taskkill /f /im ' + exec_name)
+
+            # Kill gamestream
+            print("Terminating GameStream session.")
+            if "nvstreamer.exe" in (get_process_name(p) for p in psutil.process_iter()):
+                os.system('taskkill /f /im nvstreamer.exe')
+
+            if sleep_on_exit == '1':
+                # Put computer to sleep
+                print("Going to sleep")
+                os.system("rundll32.exe powrprof.dll,SetSuspendState 0,1,0")
+
+            if debug == '1':
+                # Leave window open for debugging
+                input("Paused for debug review. Press Enter key to close.")
+
+    def reset_launcher_resolution(self, resolution, launcher_window_name):
+        # Check to ensure desired GSLP resolution is still set whenever the launcher is in focus in case it didn't reset
+        # when exiting a game
+        focused_window = win32gui.GetWindowText(win32gui.GetForegroundWindow()).lstrip()
+        # print("Trying to match", launcher_window_name, focused_window)
+        if focused_window.startswith(launcher_window_name):
+            # print("Matched")
+            current_width = int(win32api.GetSystemMetrics(0))
+            current_height = int(win32api.GetSystemMetrics(1))
+            if current_width != resolution[0] and current_height != resolution[1]:
+                print(f"Resolutions don't match, changing from {current_width}x{current_height} "
+                      f"to {resolution[0]}x{resolution[1]}")
+                self._change_display_settings(self._active_display, resolution)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-l', '--list-displays', default=False, action="store_true",
+                        help='List current displays and exit')
+    parser.add_argument('width', type=int, help='Resolution Width')
+    parser.add_argument('height', type=int, help='Resolution Height')
+    parser.add_argument('-d', '--display', default='primary', type=str, required=False,
+                        help='Which display to use (defaults to current primary)')
+    parser.add_argument('-c', '--config_file', default='', type=str, required=False,
+                        help='Configuration file to use (defaults to gamestream_playnite.ini which will be created if '
+                             'it does not exist')
+    launcher = GameStreamLauncher()
+    if '-l' in sys.argv:
+        for name, display in launcher.displays.items():
+            print(f'{name:<14} {"primary" if name == launcher.primary_display else "":<9}'
+                  f'{display["settings"].PelsWidth}x{display["settings"].PelsHeight}'
+                  f'+{display["settings"].Position_x},{display["settings"].Position_y}')
+        sys.exit(0)
+
+    args = parser.parse_args()
+    launcher.run_launcher((args.width, args.height), args.config_file, args.display)


### PR DESCRIPTION
> This is intended more to start a discussion than to be a straight merge (but you're welcome to).

I have a triple monitor setup like so: 

![image](https://user-images.githubusercontent.com/44443959/133938989-744e452c-4f69-45e2-ab80-bcc28ea8ade3.png)

... where the primary monitor is a 34" ultrawide. To make things cleaner and more repeatable I'd like to use one of the 16:9 monitors as the gamestream display, and then use DSR to enable things like 4K.

> Note the monitor you want to be primary apparently needs to be plugged into the first port on the GPU, otherwise gamestream will use that monitor no matter which your primary monitor is set to

This branch is a general refactor pass to make the tool a bit more robust, as well as adding additional functionality where it will set the target display (defaults to the current primary display) to be the primary display while changing resolutions, and will restore the layout after the application has run.

Interested in others' thoughts, and happy to help improve/make changes if desired, or not - I may be a unique use case.