### PR TITLE
add session_start and session_end options

### DIFF
--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -50,7 +50,6 @@ def reset_launcher_resolution(gamestream_width, gamestream_height, launcher_wind
 def handle_processes(paths, terminate):
     for path in paths:
         expanded_path = os.path.expandvars(paths[path])
-        print("Path: ", expanded_path)
         if os.path.exists(expanded_path):
             exec_name = os.path.basename(expanded_path)
             print("Terminating" if terminate else "Launching", expanded_path)
@@ -123,8 +122,6 @@ cfg_launcher_window_name = config['LAUNCHER'].get('launcher_window_name', 'Playn
 cfg_bg_paths = config['BACKGROUND']
 cfg_start_paths = config['SESSION_START']
 cfg_end_paths = config['SESSION_END']
-print(dict(cfg_start_paths))
-print("Hello world")
 debug = config['SETTINGS'].get('debug', '0')
 sleep_on_exit = config['SETTINGS'].get('sleep_on_exit', '0')
 close_watch_method = config['SETTINGS'].get('close_watch_method', 'window')

--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -47,6 +47,25 @@ def reset_launcher_resolution(gamestream_width, gamestream_height, launcher_wind
             print("Resolutions don't match, changing from", current_width, current_height, "to", gamestream_width, gamestream_height)
             set_resolution(gamestream_width, gamestream_height)
 
+def handle_processes(paths, terminate):
+    for path in paths:
+        expanded_path = os.path.expandvars(paths[path])
+        print("Path: ", expanded_path)
+        if os.path.exists(expanded_path):
+            exec_name = os.path.basename(expanded_path)
+            print("Terminating" if terminate else "Launching", expanded_path)
+            # Terminate even if launching, so that we kill it if it's already running
+            if exec_name in (get_process_name(p) for p in psutil.process_iter()):
+                os.system('taskkill /f /im ' + exec_name)
+            if not terminate:
+                # Start the process
+                subprocess.Popen(expanded_path)
+
+def launch_processes(paths):
+    handle_processes(paths, False)
+
+def kill_processes(paths):
+    handle_processes(paths, True)
 
 # Define a default config file to write if we're missing one
 config_filename = 'gamestream_playnite.ini'
@@ -60,6 +79,14 @@ launcher_window_name = Playnite
 # List as many exe's or bat's as you want here. They will run at the start of the GameStream session and be killed at the end.
 # background_exe_1 = C:\Program Files (x86)\JoyToKey\JoyToKey.exe
 # background_exe_2 = C:\WINDOWS\system32\mspaint.exe
+
+[SESSION_START]
+# List as many exe's or bat's as you want here. They will run when the GameStream session begins, but won't be killed when it ends.
+# start_exe_1 = C:\Some\Path\enable_bluetooth_adapter.bat
+
+[SESSION_END]
+# List as many exe's or bat's as you want here. They will run when the GameStream session ends.
+# end_exe_1 = C:\Some\Path\disable_bluetooth_adapter.bat
 
 [SETTINGS]
 # Set debug = 1 to leave a window running after gamestream to see error messages from GSLP
@@ -94,6 +121,10 @@ config.read(config_filename)
 cfg_launcher_path = config['LAUNCHER'].get('launcher_path', r'%LOCALAPPDATA%\Playnite\Playnite.FullscreenApp.exe')
 cfg_launcher_window_name = config['LAUNCHER'].get('launcher_window_name', 'Playnite')
 cfg_bg_paths = config['BACKGROUND']
+cfg_start_paths = config['SESSION_START']
+cfg_end_paths = config['SESSION_END']
+print(dict(cfg_start_paths))
+print("Hello world")
 debug = config['SETTINGS'].get('debug', '0')
 sleep_on_exit = config['SETTINGS'].get('sleep_on_exit', '0')
 close_watch_method = config['SETTINGS'].get('close_watch_method', 'window')
@@ -103,22 +134,14 @@ launcher_exec_name = os.path.basename(cfg_launcher_path)
 # Set resolution to target
 set_resolution(gamestream_width, gamestream_height)
 
-# Start background programs, if they're available
-for path in cfg_bg_paths:
-    expanded_path = os.path.expandvars(cfg_bg_paths[path])
-    if os.path.exists(expanded_path):
-        print("Launching", expanded_path)
-        exec_name = os.path.basename(expanded_path)
-        # Kill the process first if it's already running
-        if exec_name in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + exec_name)
-        # Start the process
-        subprocess.Popen(expanded_path)
+# Start background and session_start programs, if they're available
+launch_processes(cfg_bg_paths)
+launch_processes(cfg_start_paths)
 
 # A launcher value of false will create a wait inside of the console instead watching a program
 if cfg_launcher_path.lower() == "false":
     input('Press enter to end the GameStream session.')
-else:    
+else:
     # Minimize all windows
     print("Minimizing windows")
     pyautogui.hotkey('winleft', 'd')
@@ -129,7 +152,7 @@ else:
             os.system('taskkill /f /im ' + "Playnite.FullscreenApp.exe")
         if "Playnite.DesktopApp.exe" in (get_process_name(p) for p in psutil.process_iter()):
             os.system('taskkill /f /im ' + "Playnite.DesktopApp.exe")
-    
+
         # Move mouse cursor into the lower-right corner to pseudo-hide it because sticks out in playnite fullscreen
         pyautogui.FAILSAFE = False
         pyautogui.moveTo(9999, 9999, duration = 0)
@@ -177,14 +200,9 @@ else:
         print("No valid close_watch_method in the config. Press Enter when you're done.")
         input()
 
-# Terminate background programs, if they're available
-for path in cfg_bg_paths:
-    expanded_path = os.path.expandvars(cfg_bg_paths[path])
-    if os.path.exists(expanded_path):
-        exec_name = os.path.basename(expanded_path)
-        print("Terminating", exec_name)
-        if exec_name in (get_process_name(p) for p in psutil.process_iter()):
-            os.system('taskkill /f /im ' + exec_name)
+# Terminate background and launch session_end programs, if they're available
+kill_processes(cfg_bg_paths)
+launch_processes(cfg_end_paths)
 
 # Kill gamestream
 print("Terminating GameStream session.")


### PR DESCRIPTION
There are some cases where `BACKGROUND` isn't sufficient, as you may want to launch different applications on session start / end.

My particular use case is that I have a script (actually, two scripts) that change which bluetooth adapter is currently being used by Windows. It switches between the one in my PC (used for my bluetooth keyboard) and the one in my TV room (so that I can use my controller).
It would be possible to have a daemon or background process that watches when something started by GSLP is opened and closed (and then toggling the adapter), but it's a lot simpler this way. 

This PR adds `SESSION_START` and `SESSION_END` sections to the config, where users can stick scripts to be run at session start and end respectively 😄 