### PR TITLE
Add support for specifying refresh rate

### DIFF
--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -20,7 +20,7 @@ def set_resolution(gamestream_width, gamestream_height,refresh_rate=None):
     if refresh_rate is None:
         print("Switching resolution to {0}x{1}".format(gamestream_width, gamestream_height))
     else:
-        print("Switching resolution to {0}x{1} at {2}Hz".format(gamestream_width, gamestream_height))
+        print("Switching resolution to {0}x{1} at {2}Hz".format(gamestream_width, gamestream_height,refresh_rate))
     devmode = pywintypes.DEVMODEType()
     devmode.PelsWidth = int(gamestream_width)
     devmode.PelsHeight = int(gamestream_height)


### PR DESCRIPTION
I have a fake hdmi dongle and when I set 1440p it'll revert to 60Hz. I've added support for a commandline flag -r after which you specify a refresh rate in Hz. It doesn't do any checking to see if it'll work but if your monitor supports the refresh rate it will change it as requested. I haven't done extensive testing but if I tell my monitor to change to 60Hz it will change to 59.95 so it seems to pick the nearest supported frequency or perhaps just automatically substitutes certain common modes. since I used a flag you can place the -r Hz anywhere in the arguments and anything that depends on the old argument format is unaffected.