### PR TITLE
> Added sleep after minimizing all windows to prevent playnite itself from being minimized

### DIFF
--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -172,6 +172,7 @@ else:
     # Minimize all windows
     print("Minimizing windows")
     pyautogui.hotkey('winleft', 'd')
+    sleep(1)
 
     # Playnite has to be killed before it will start in fullscreen mode
     if "Playnite" in launcher_exec_name:

--- a/gamestream_launchpad.py
+++ b/gamestream_launchpad.py
@@ -172,7 +172,7 @@ else:
     # Minimize all windows
     print("Minimizing windows")
     pyautogui.hotkey('winleft', 'd')
-    sleep(1)
+    sleep(3)
 
     # Playnite has to be killed before it will start in fullscreen mode
     if "Playnite" in launcher_exec_name:


### PR DESCRIPTION
Running the launchpad would always end up with playnite minimized, and the ShowWindow and SetForegroundWindow functions didn't seem to work. added a 1s sleep to stop the win+d from affecting playnite.

this probably happens because changing the resolution and refresh rate takes a bit longer than just changing the resolution. the win+d command gets stuck in queue and executes after playnite is in the process of launching. 1s works most of the time, 3s works all of the time. alternative fix would probably be to simply move set_resolution to after windows are minimized.